### PR TITLE
Bump source/bytecode version to java 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <maven.compiler.source>1.5</maven.compiler.source>
-    <maven.compiler.target>1.5</maven.compiler.target>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <build>


### PR DESCRIPTION
Since this is used as a fixture for ATH (`WorkflowPluginTest.parallelTests`), it needs to be using java 6 or above to be compatible with Java 11 ATH is using now or the tests needs to be rewritten.

@jglick, PTAL